### PR TITLE
tela de login melhorada

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -7,22 +7,22 @@
           <%= render "users/shared/error_messages", resource: resource %>
           <div class="field">
             <%= f.label :email %><br />
-            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control", placeholder: "Digite seu Email..."  %>
           </div>
           <div class="field">
-            <%= f.label :password %>
+            <%= f.label "Senha" %>
             <% if @minimum_password_length %>
-            <em>(<%= @minimum_password_length %> characters minimum)</em>
+            <em>(<%= @minimum_password_length %> caracters no minimo)</em>
             <% end %><br />
             <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
           </div>
           <div class="field">
-            <%= f.label :password_confirmation %><br />
+            <%= f.label "Confirme sua senha" %><br />
             <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
           </div>
           <div class="actions">
-            <%= f.submit "Sign up", class: "btn btn-success mt-3 me-3" %>
-            <%= link_to "Log in", new_session_path(resource_name), class: "btn btn-primary mt-3 me-3" %>
+            <%= f.submit "Cadastrar", class: "btn btn-success mt-3 me-3 mb-3 col-md-12" %>
+            Já tem uma conta? <%= link_to "Entre", new_session_path(resource_name), class: "link" %>
           </div>
         <% end %>
     </article>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,30 +1,30 @@
 <div class="login-page-container">
   <div class="card box">
     <article class="card-body">
-      <h4 class="card-title text-center mb-4 mt-1">Login</h4>
+      <h4 class="card-title text-center mb-4 mt-1">Entrar</h4>
       <hr>
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <%= render "users/shared/error_messages", resource: resource %>
         <div class="field mb-2">
           <%= f.label :email %><br />
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control", placeholder: "Digite seu Email..." %>
         </div>
 
         <div class="field">
-          <%= f.label :password %><br />
+          <%= f.label "Senha" %><br />
           <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
         </div>
 
         <% if devise_mapping.rememberable? %>
           <div class="field mt-2 mb-2">
             <%= f.check_box :remember_me, class: "form-check-input" %>
-            <%= f.label :remember_me  %>
+            <%= f.label "Salvar login"  %>
           </div>
         <% end %>
 
         <div class="actions">
-          <%= f.submit "Log in", class: "btn btn-success mt-3 me-3" %>
-          <%= link_to "Sign up", new_registration_path(resource_name), class: "btn btn-primary mt-3 me-3" %><br />
+          <%= f.submit "Entrar", class: "btn btn-success mt-3 mb-3 col-md-12" %>
+          Novo por aqui? <%= link_to "Cadastrar-se", new_registration_path(resource_name), class: "link" %><br />
         </div>
       <% end %>
     </article>


### PR DESCRIPTION
### Conteudo 
Tela de login precisa de tradução, necessita tirar os textos em inglês

### Solução
Foi alterado os textos e colocado em português, removido o botão de login e colocado um texto perguntando se está cadastrado ou se não tem conta, e botão principal aumentado.